### PR TITLE
Add replica set to mongoid

### DIFF
--- a/config/mongoid.yml
+++ b/config/mongoid.yml
@@ -10,6 +10,7 @@ common: &default_client
     ssl: <%= ENV['MONGOID_USE_SSL'] || false %>
     ssl_verify: <%= ENV['MONGOID_SSL_VERIFY'] || true %>
     auth_source: <%= ENV['MONGOID_AUTH_SOURCE'] %>
+    replica_set: <%= ENV['MONGOID_REPLICA_SET'] %>
 
 common_uri: &default_uri
   uri: <%= ENV['MONGOHQ_URL'] %>


### PR DESCRIPTION
This PR is a companion of: https://github.com/appsembler/edx-platform/pull/505

It adds forum support for mongo 3.6 and above, since now it requires to specify the replica set name in mongoid.

It also requires https://github.com/appsembler/configuration/pull/273 and https://github.com/appsembler/edx-configs/pull/745 to work. 